### PR TITLE
Fixing button bugs

### DIFF
--- a/src/components/_buttons.scss
+++ b/src/components/_buttons.scss
@@ -17,7 +17,8 @@
 	}
 	
 	&:hover,
-	&:active {
+	&:active,
+	&:focus {
 	
 		color: $green;
 		background: transparent;
@@ -30,7 +31,8 @@
 		background: transparent;
 
 		&:hover,
-		&:active {
+		&:active,
+		&:focus {
 
 			background-color: $green;
 			color: $white;
@@ -53,7 +55,8 @@
 		}
 
 		&:hover,
-		&:active {
+		&:active,
+		&:focus {
 
 			color: $green;
 			background-color: $white;

--- a/src/components/_hero.scss
+++ b/src/components/_hero.scss
@@ -86,6 +86,12 @@ body.home #after-header-widgets {
 		
 	}
 
+	.button {
+
+		margin: 5px;
+		
+	}
+
 	// Tint/overlay
 	&:after {
 	

--- a/src/components/_masthead.scss
+++ b/src/components/_masthead.scss
@@ -50,12 +50,14 @@
 			background-colour: $green;
 			margin-left: 0;
 			margin-top: 1rem;
+			box-shadow: 0 3px 60px #000;
 
 			@include mq( $bp_lap ) {
 
 				background-colour: transparent;
 				margin-right: -$gutter_x;
 				margin-top: 0;
+				box-shadow: none;
 
 			}
 
@@ -185,6 +187,12 @@
 		    right: 0;
 		    box-shadow: 0 0 0 1px $green, 0 7px 0 1px $green, 0 14px 0 1px $green;
 		    width: 1em;
+
+	    }
+
+	    &.toggled-on {
+
+	    	margin-top: 4px;
 
 	    }
 


### PR DESCRIPTION
Adding focus state and fixing green mess in the home hero. Home page hero buttons now have margin to add spacing, and a box shadow is added to the menu to stop it overlapping the buttons which are also green. Also stops the menu button moving on toggle